### PR TITLE
Update api version

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,6 +3,7 @@ name: HarmonyScoreboard
 version: 1.8.0
 description: Light Weight Asynchronous Scoreboard
 author: Oreoezi
+api-version: 1.16
 softdepend: [PlaceholderAPI]
 commands:
  harmonyboard:


### PR DESCRIPTION
Not specifying the api version causes legacy layers to load. It's not needed, and the plugin will still work on all versions.